### PR TITLE
add E, M, S, x, y, z, u, r, f, d, l, b moves.

### DIFF
--- a/lib/cube.js
+++ b/lib/cube.js
@@ -1,32 +1,36 @@
 (function() {
-  var BL, BR, Cube, DB, DBL, DF, DFR, DL, DLF, DR, DRB, FL, FR, UB, UBR, UF, UFL, UL, ULB, UR, URF, cornerColor, cornerFacelet, edgeColor, edgeFacelet, ref, ref1, ref2;
+  var B, BL, BR, Cube, D, DB, DBL, DF, DFR, DL, DLF, DR, DRB, F, FL, FR, L, R, U, UB, UBR, UF, UFL, UL, ULB, UR, URF, centerColor, centerFacelet, cornerColor, cornerFacelet, edgeColor, edgeFacelet, ref, ref1, ref2, ref3;
 
-  ref = [0, 1, 2, 3, 4, 5, 6, 7], URF = ref[0], UFL = ref[1], ULB = ref[2], UBR = ref[3], DFR = ref[4], DLF = ref[5], DBL = ref[6], DRB = ref[7];
+  ref = [0, 1, 2, 3, 4, 5], U = ref[0], R = ref[1], F = ref[2], D = ref[3], L = ref[4], B = ref[5];
 
-  ref1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], UR = ref1[0], UF = ref1[1], UL = ref1[2], UB = ref1[3], DR = ref1[4], DF = ref1[5], DL = ref1[6], DB = ref1[7], FR = ref1[8], FL = ref1[9], BL = ref1[10], BR = ref1[11];
+  ref1 = [0, 1, 2, 3, 4, 5, 6, 7], URF = ref1[0], UFL = ref1[1], ULB = ref1[2], UBR = ref1[3], DFR = ref1[4], DLF = ref1[5], DBL = ref1[6], DRB = ref1[7];
 
-  ref2 = (function() {
-    var B, D, F, L, R, U;
-    U = function(x) {
+  ref2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], UR = ref2[0], UF = ref2[1], UL = ref2[2], UB = ref2[3], DR = ref2[4], DF = ref2[5], DL = ref2[6], DB = ref2[7], FR = ref2[8], FL = ref2[9], BL = ref2[10], BR = ref2[11];
+
+  ref3 = (function() {
+    var _B, _D, _F, _L, _R, _U;
+    _U = function(x) {
       return x - 1;
     };
-    R = function(x) {
-      return U(9) + x;
+    _R = function(x) {
+      return _U(9) + x;
     };
-    F = function(x) {
-      return R(9) + x;
+    _F = function(x) {
+      return _R(9) + x;
     };
-    D = function(x) {
-      return F(9) + x;
+    _D = function(x) {
+      return _F(9) + x;
     };
-    L = function(x) {
-      return D(9) + x;
+    _L = function(x) {
+      return _D(9) + x;
     };
-    B = function(x) {
-      return L(9) + x;
+    _B = function(x) {
+      return _L(9) + x;
     };
-    return [[[U(9), R(1), F(3)], [U(7), F(1), L(3)], [U(1), L(1), B(3)], [U(3), B(1), R(3)], [D(3), F(9), R(7)], [D(1), L(9), F(7)], [D(7), B(9), L(7)], [D(9), R(9), B(7)]], [[U(6), R(2)], [U(8), F(2)], [U(4), L(2)], [U(2), B(2)], [D(6), R(8)], [D(2), F(8)], [D(4), L(8)], [D(8), B(8)], [F(6), R(4)], [F(4), L(6)], [B(6), L(4)], [B(4), R(6)]]];
-  })(), cornerFacelet = ref2[0], edgeFacelet = ref2[1];
+    return [[4, 13, 22, 31, 40, 49], [[_U(9), _R(1), _F(3)], [_U(7), _F(1), _L(3)], [_U(1), _L(1), _B(3)], [_U(3), _B(1), _R(3)], [_D(3), _F(9), _R(7)], [_D(1), _L(9), _F(7)], [_D(7), _B(9), _L(7)], [_D(9), _R(9), _B(7)]], [[_U(6), _R(2)], [_U(8), _F(2)], [_U(4), _L(2)], [_U(2), _B(2)], [_D(6), _R(8)], [_D(2), _F(8)], [_D(4), _L(8)], [_D(8), _B(8)], [_F(6), _R(4)], [_F(4), _L(6)], [_B(6), _L(4)], [_B(4), _R(6)]]];
+  })(), centerFacelet = ref3[0], cornerFacelet = ref3[1], edgeFacelet = ref3[2];
+
+  centerColor = ['U', 'R', 'F', 'D', 'L', 'B'];
 
   cornerColor = [['U', 'R', 'F'], ['U', 'F', 'L'], ['U', 'L', 'B'], ['U', 'B', 'R'], ['D', 'F', 'R'], ['D', 'L', 'F'], ['D', 'B', 'L'], ['D', 'R', 'B']];
 
@@ -42,6 +46,14 @@
       } else {
         this.identity();
       }
+      this.newCenter = (function() {
+        var k, results;
+        results = [];
+        for (x = k = 0; k <= 5; x = ++k) {
+          results.push(0);
+        }
+        return results;
+      })();
       this.newCp = (function() {
         var k, results;
         results = [];
@@ -77,6 +89,7 @@
     }
 
     Cube.prototype.init = function(state) {
+      this.center = state.center.slice(0);
       this.co = state.co.slice(0);
       this.ep = state.ep.slice(0);
       this.cp = state.cp.slice(0);
@@ -85,6 +98,7 @@
 
     Cube.prototype.identity = function() {
       var x;
+      this.center = [0, 1, 2, 3, 4, 5];
       this.cp = [0, 1, 2, 3, 4, 5, 6, 7];
       this.co = (function() {
         var k, results;
@@ -107,6 +121,7 @@
 
     Cube.prototype.toJSON = function() {
       return {
+        center: this.center,
         cp: this.cp,
         co: this.co,
         ep: this.ep,
@@ -115,12 +130,10 @@
     };
 
     Cube.prototype.asString = function() {
-      var c, corner, edge, i, k, l, len, m, n, o, ori, p, ref3, ref4, result;
+      var corner, edge, i, k, l, m, n, o, ori, p, result;
       result = [];
-      ref3 = [[4, 'U'], [13, 'R'], [22, 'F'], [31, 'D'], [40, 'L'], [49, 'B']];
-      for (k = 0, len = ref3.length; k < len; k++) {
-        ref4 = ref3[k], i = ref4[0], c = ref4[1];
-        result[i] = c;
+      for (i = k = 0; k <= 5; i = ++k) {
+        result[9 * i + 4] = centerColor[this.center[i]];
       }
       for (i = l = 0; l <= 7; i = ++l) {
         corner = this.cp[i];
@@ -140,25 +153,32 @@
     };
 
     Cube.fromString = function(str) {
-      var col1, col2, cube, i, j, k, l, m, o, ori, p, ref3;
+      var col1, col2, cube, i, j, k, l, m, o, ori, p, q, ref4, s;
       cube = new Cube;
-      for (i = k = 0; k <= 7; i = ++k) {
-        for (ori = l = 0; l <= 2; ori = ++l) {
-          if ((ref3 = str[cornerFacelet[i][ori]]) === 'U' || ref3 === 'D') {
+      for (i = k = 0; k <= 5; i = ++k) {
+        for (j = l = 0; l <= 5; j = ++l) {
+          if (str[9 * i + 4] === centerColor[j]) {
+            cube.center[i] = j;
+          }
+        }
+      }
+      for (i = m = 0; m <= 7; i = ++m) {
+        for (ori = o = 0; o <= 2; ori = ++o) {
+          if ((ref4 = str[cornerFacelet[i][ori]]) === 'U' || ref4 === 'D') {
             break;
           }
         }
         col1 = str[cornerFacelet[i][(ori + 1) % 3]];
         col2 = str[cornerFacelet[i][(ori + 2) % 3]];
-        for (j = m = 0; m <= 7; j = ++m) {
+        for (j = p = 0; p <= 7; j = ++p) {
           if (col1 === cornerColor[j][1] && col2 === cornerColor[j][2]) {
             cube.cp[i] = j;
             cube.co[i] = ori % 3;
           }
         }
       }
-      for (i = o = 0; o <= 11; i = ++o) {
-        for (j = p = 0; p <= 11; j = ++p) {
+      for (i = q = 0; q <= 11; i = ++q) {
+        for (j = s = 0; s <= 11; j = ++s) {
           if (str[edgeFacelet[i][0]] === edgeColor[j][0] && str[edgeFacelet[i][1]] === edgeColor[j][1]) {
             cube.ep[i] = j;
             cube.eo[i] = 0;
@@ -184,14 +204,14 @@
         return min + (Math.random() * (max - min + 1) | 0);
       };
       mixPerm = function(arr) {
-        var i, k, max, r, ref3, ref4, ref5, results;
+        var i, k, max, r, ref4, ref5, ref6, results;
         max = arr.length - 1;
         results = [];
-        for (i = k = 0, ref3 = max - 2; 0 <= ref3 ? k <= ref3 : k >= ref3; i = 0 <= ref3 ? ++k : --k) {
+        for (i = k = 0, ref4 = max - 2; 0 <= ref4 ? k <= ref4 : k >= ref4; i = 0 <= ref4 ? ++k : --k) {
           r = randint(i, max);
           if (i !== r) {
-            ref4 = [arr[r], arr[i]], arr[i] = ref4[0], arr[r] = ref4[1];
-            results.push((ref5 = [arr[max - 1], arr[max]], arr[max] = ref5[0], arr[max - 1] = ref5[1], ref5));
+            ref5 = [arr[r], arr[i]], arr[i] = ref5[0], arr[r] = ref5[1];
+            results.push((ref6 = [arr[max - 1], arr[max]], arr[max] = ref6[0], arr[max - 1] = ref6[1], ref6));
           } else {
             results.push(void 0);
           }
@@ -199,9 +219,9 @@
         return results;
       };
       randOri = function(arr, max) {
-        var i, k, ori, ref3;
+        var i, k, ori, ref4;
         ori = 0;
-        for (i = k = 0, ref3 = arr.length - 2; 0 <= ref3 ? k <= ref3 : k >= ref3; i = 0 <= ref3 ? ++k : --k) {
+        for (i = k = 0, ref4 = arr.length - 2; 0 <= ref4 ? k <= ref4 : k >= ref4; i = 0 <= ref4 ? ++k : --k) {
           ori += (arr[i] = randint(0, max - 1));
         }
         return arr[arr.length - 1] = (max - ori % max) % max;
@@ -221,51 +241,69 @@
     };
 
     Cube.prototype.isSolved = function() {
-      var c, e, k, l;
-      for (c = k = 0; k <= 7; c = ++k) {
-        if (this.cp[c] !== c) {
-          return false;
-        }
-        if (this.co[c] !== 0) {
+      var c, cent, clone, e, k, l, m;
+      clone = this.clone();
+      clone.move(clone.upright());
+      for (cent = k = 0; k <= 5; cent = ++k) {
+        if (clone.center[cent] !== cent) {
           return false;
         }
       }
-      for (e = l = 0; l <= 11; e = ++l) {
-        if (this.ep[e] !== e) {
+      for (c = l = 0; l <= 7; c = ++l) {
+        if (clone.cp[c] !== c) {
           return false;
         }
-        if (this.eo[e] !== 0) {
+        if (clone.co[c] !== 0) {
+          return false;
+        }
+      }
+      for (e = m = 0; m <= 11; e = ++m) {
+        if (clone.ep[e] !== e) {
+          return false;
+        }
+        if (clone.eo[e] !== 0) {
           return false;
         }
       }
       return true;
     };
 
+    Cube.prototype.centerMultiply = function(other) {
+      var from, k, ref4, to;
+      for (to = k = 0; k <= 5; to = ++k) {
+        from = other.center[to];
+        this.newCenter[to] = this.center[from];
+      }
+      ref4 = [this.newCenter, this.center], this.center = ref4[0], this.newCenter = ref4[1];
+      return this;
+    };
+
     Cube.prototype.cornerMultiply = function(other) {
-      var from, k, ref3, ref4, to;
+      var from, k, ref4, ref5, to;
       for (to = k = 0; k <= 7; to = ++k) {
         from = other.cp[to];
         this.newCp[to] = this.cp[from];
         this.newCo[to] = (this.co[from] + other.co[to]) % 3;
       }
-      ref3 = [this.newCp, this.cp], this.cp = ref3[0], this.newCp = ref3[1];
-      ref4 = [this.newCo, this.co], this.co = ref4[0], this.newCo = ref4[1];
+      ref4 = [this.newCp, this.cp], this.cp = ref4[0], this.newCp = ref4[1];
+      ref5 = [this.newCo, this.co], this.co = ref5[0], this.newCo = ref5[1];
       return this;
     };
 
     Cube.prototype.edgeMultiply = function(other) {
-      var from, k, ref3, ref4, to;
+      var from, k, ref4, ref5, to;
       for (to = k = 0; k <= 11; to = ++k) {
         from = other.ep[to];
         this.newEp[to] = this.ep[from];
         this.newEo[to] = (this.eo[from] + other.eo[to]) % 2;
       }
-      ref3 = [this.newEp, this.ep], this.ep = ref3[0], this.newEp = ref3[1];
-      ref4 = [this.newEo, this.eo], this.eo = ref4[0], this.newEo = ref4[1];
+      ref4 = [this.newEp, this.ep], this.ep = ref4[0], this.newEp = ref4[1];
+      ref5 = [this.newEo, this.eo], this.eo = ref5[0], this.newEo = ref5[1];
       return this;
     };
 
     Cube.prototype.multiply = function(other) {
+      this.centerMultiply(other);
       this.cornerMultiply(other);
       this.edgeMultiply(other);
       return this;
@@ -273,35 +311,59 @@
 
     Cube.moves = [
       {
+        center: [0, 1, 2, 3, 4, 5],
         cp: [UBR, URF, UFL, ULB, DFR, DLF, DBL, DRB],
         co: [0, 0, 0, 0, 0, 0, 0, 0],
         ep: [UB, UR, UF, UL, DR, DF, DL, DB, FR, FL, BL, BR],
         eo: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       }, {
+        center: [0, 1, 2, 3, 4, 5],
         cp: [DFR, UFL, ULB, URF, DRB, DLF, DBL, UBR],
         co: [2, 0, 0, 1, 1, 0, 0, 2],
         ep: [FR, UF, UL, UB, BR, DF, DL, DB, DR, FL, BL, UR],
         eo: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       }, {
+        center: [0, 1, 2, 3, 4, 5],
         cp: [UFL, DLF, ULB, UBR, URF, DFR, DBL, DRB],
         co: [1, 2, 0, 0, 2, 1, 0, 0],
         ep: [UR, FL, UL, UB, DR, FR, DL, DB, UF, DF, BL, BR],
         eo: [0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0]
       }, {
+        center: [0, 1, 2, 3, 4, 5],
         cp: [URF, UFL, ULB, UBR, DLF, DBL, DRB, DFR],
         co: [0, 0, 0, 0, 0, 0, 0, 0],
         ep: [UR, UF, UL, UB, DF, DL, DB, DR, FR, FL, BL, BR],
         eo: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       }, {
+        center: [0, 1, 2, 3, 4, 5],
         cp: [URF, ULB, DBL, UBR, DFR, UFL, DLF, DRB],
         co: [0, 1, 2, 0, 0, 2, 1, 0],
         ep: [UR, UF, BL, UB, DR, DF, FL, DB, FR, UL, DL, BR],
         eo: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       }, {
+        center: [0, 1, 2, 3, 4, 5],
         cp: [URF, UFL, UBR, DRB, DFR, DLF, ULB, DBL],
         co: [0, 0, 1, 2, 0, 0, 2, 1],
         ep: [UR, UF, UL, BR, DR, DF, DL, BL, FR, FL, UB, DB],
         eo: [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1]
+      }, {
+        center: [U, F, L, D, B, R],
+        cp: [URF, UFL, ULB, UBR, DFR, DLF, DBL, DRB],
+        co: [0, 0, 0, 0, 0, 0, 0, 0],
+        ep: [UR, UF, UL, UB, DR, DF, DL, DB, FL, BL, BR, FR],
+        eo: [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1]
+      }, {
+        center: [B, R, U, F, L, D],
+        cp: [URF, UFL, ULB, UBR, DFR, DLF, DBL, DRB],
+        co: [0, 0, 0, 0, 0, 0, 0, 0],
+        ep: [UR, UB, UL, DB, DR, UF, DL, DF, FR, FL, BL, BR],
+        eo: [0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0]
+      }, {
+        center: [L, U, F, R, D, B],
+        cp: [URF, UFL, ULB, UBR, DFR, DLF, DBL, DRB],
+        co: [0, 0, 0, 0, 0, 0, 0, 0],
+        ep: [UL, UF, DL, UB, UR, DF, DR, DB, FR, FL, BL, BR],
+        eo: [1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0]
       }
     ];
 
@@ -311,7 +373,19 @@
       F: 2,
       D: 3,
       L: 4,
-      B: 5
+      B: 5,
+      E: 6,
+      M: 7,
+      S: 8,
+      x: 9,
+      y: 10,
+      z: 11,
+      u: 12,
+      r: 13,
+      f: 14,
+      d: 15,
+      l: 16,
+      b: 17
     };
 
     faceNames = {
@@ -320,16 +394,28 @@
       2: 'F',
       3: 'D',
       4: 'L',
-      5: 'B'
+      5: 'B',
+      6: 'E',
+      7: 'M',
+      8: 'S',
+      9: 'x',
+      10: 'y',
+      11: 'z',
+      12: 'u',
+      13: 'r',
+      14: 'f',
+      15: 'd',
+      16: 'l',
+      17: 'b'
     };
 
     parseAlg = function(arg) {
-      var k, len, move, part, power, ref3, results;
+      var k, len, move, part, power, ref4, results;
       if (typeof arg === 'string') {
-        ref3 = arg.split(/\s+/);
+        ref4 = arg.split(/\s+/);
         results = [];
-        for (k = 0, len = ref3.length; k < len; k++) {
-          part = ref3[k];
+        for (k = 0, len = ref4.length; k < len; k++) {
+          part = ref4[k];
           if (part.length === 0) {
             continue;
           }
@@ -362,27 +448,73 @@
     };
 
     Cube.prototype.move = function(arg) {
-      var face, k, l, len, move, power, ref3, ref4, x;
-      ref3 = parseAlg(arg);
-      for (k = 0, len = ref3.length; k < len; k++) {
-        move = ref3[k];
+      var face, k, l, len, move, power, ref4, ref5, x;
+      ref4 = parseAlg(arg);
+      for (k = 0, len = ref4.length; k < len; k++) {
+        move = ref4[k];
         face = move / 3 | 0;
         power = move % 3;
-        for (x = l = 0, ref4 = power; 0 <= ref4 ? l <= ref4 : l >= ref4; x = 0 <= ref4 ? ++l : --l) {
+        for (x = l = 0, ref5 = power; 0 <= ref5 ? l <= ref5 : l >= ref5; x = 0 <= ref5 ? ++l : --l) {
           this.multiply(Cube.moves[face]);
         }
       }
       return this;
     };
 
+    Cube.prototype.upright = function() {
+      var clone, i, j, k, l, result;
+      clone = this.clone();
+      result = [];
+      for (i = k = 0; k <= 5; i = ++k) {
+        if (clone.center[i] === F) {
+          break;
+        }
+      }
+      switch (i) {
+        case D:
+          result.push("x");
+          break;
+        case U:
+          result.push("x'");
+          break;
+        case B:
+          result.push("x2");
+          break;
+        case R:
+          result.push("y");
+          break;
+        case L:
+          result.push("y'");
+      }
+      if (result.length) {
+        clone.move(result[0]);
+      }
+      for (j = l = 0; l <= 5; j = ++l) {
+        if (clone.center[j] === U) {
+          break;
+        }
+      }
+      switch (j) {
+        case L:
+          result.push("z");
+          break;
+        case R:
+          result.push("z'");
+          break;
+        case D:
+          result.push("z2");
+      }
+      return result.join(' ');
+    };
+
     Cube.inverse = function(arg) {
       var face, k, len, move, power, result, str;
       result = (function() {
-        var k, len, ref3, results;
-        ref3 = parseAlg(arg);
+        var k, len, ref4, results;
+        ref4 = parseAlg(arg);
         results = [];
-        for (k = 0, len = ref3.length; k < len; k++) {
-          move = ref3[k];
+        for (k = 0, len = ref4.length; k < len; k++) {
+          move = ref4[k];
           face = move / 3 | 0;
           power = move % 3;
           results.push(face * 3 + -(power - 1) + 1);
@@ -411,6 +543,24 @@
         return result[0];
       }
     };
+
+    Cube.moves.push(new Cube().move("R M' L'").toJSON());
+
+    Cube.moves.push(new Cube().move("U E' D'").toJSON());
+
+    Cube.moves.push(new Cube().move("F S B'").toJSON());
+
+    Cube.moves.push(new Cube().move("U E'").toJSON());
+
+    Cube.moves.push(new Cube().move("R M'").toJSON());
+
+    Cube.moves.push(new Cube().move("F S").toJSON());
+
+    Cube.moves.push(new Cube().move("D E").toJSON());
+
+    Cube.moves.push(new Cube().move("L M").toJSON());
+
+    Cube.moves.push(new Cube().move("B S'").toJSON());
 
     return Cube;
 

--- a/lib/solve.js
+++ b/lib/solve.js
@@ -1,13 +1,15 @@
 (function() {
-  var BL, BR, Cnk, Cube, DB, DBL, DF, DFR, DL, DLF, DR, DRB, FL, FR, Include, N_FLIP, N_FRtoBR, N_PARITY, N_SLICE1, N_SLICE2, N_TWIST, N_UBtoDF, N_URFtoDLF, N_URtoDF, N_URtoUL, UB, UBR, UF, UFL, UL, ULB, UR, URF, allMoves1, allMoves2, computeMoveTable, computePruningTable, factorial, key, max, mergeURtoDF, moveTableParams, nextMoves1, nextMoves2, permutationIndex, pruning, pruningTableParams, ref, ref1, rotateLeft, rotateRight, value,
+  var B, BL, BR, Cnk, Cube, D, DB, DBL, DF, DFR, DL, DLF, DR, DRB, F, FL, FR, Include, L, N_FLIP, N_FRtoBR, N_PARITY, N_SLICE1, N_SLICE2, N_TWIST, N_UBtoDF, N_URFtoDLF, N_URtoDF, N_URtoUL, R, U, UB, UBR, UF, UFL, UL, ULB, UR, URF, allMoves1, allMoves2, computeMoveTable, computePruningTable, faceNames, faceNums, factorial, key, max, mergeURtoDF, moveTableParams, nextMoves1, nextMoves2, permutationIndex, pruning, pruningTableParams, ref, ref1, ref2, rotateLeft, rotateRight, value,
     slice1 = [].slice,
     indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   Cube = this.Cube || require('./cube');
 
-  ref = [0, 1, 2, 3, 4, 5, 6, 7], URF = ref[0], UFL = ref[1], ULB = ref[2], UBR = ref[3], DFR = ref[4], DLF = ref[5], DBL = ref[6], DRB = ref[7];
+  ref = [0, 1, 2, 3, 4, 5], U = ref[0], R = ref[1], F = ref[2], D = ref[3], L = ref[4], B = ref[5];
 
-  ref1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], UR = ref1[0], UF = ref1[1], UL = ref1[2], UB = ref1[3], DR = ref1[4], DF = ref1[5], DL = ref1[6], DB = ref1[7], FR = ref1[8], FL = ref1[9], BL = ref1[10], BR = ref1[11];
+  ref1 = [0, 1, 2, 3, 4, 5, 6, 7], URF = ref1[0], UFL = ref1[1], ULB = ref1[2], UBR = ref1[3], DFR = ref1[4], DLF = ref1[5], DBL = ref1[6], DRB = ref1[7];
+
+  ref2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], UR = ref2[0], UF = ref2[1], UL = ref2[2], UB = ref2[3], DR = ref2[4], DF = ref2[5], DL = ref2[6], DB = ref2[7], FR = ref2[8], FL = ref2[9], BL = ref2[10], BR = ref2[11];
 
   Cnk = function(n, k) {
     var i, j, s;
@@ -30,9 +32,9 @@
   };
 
   factorial = function(n) {
-    var f, i, m, ref2;
+    var f, i, m, ref3;
     f = 1;
-    for (i = m = 2, ref2 = n; 2 <= ref2 ? m <= ref2 : m >= ref2; i = 2 <= ref2 ? ++m : --m) {
+    for (i = m = 2, ref3 = n; 2 <= ref3 ? m <= ref3 : m >= ref3; i = 2 <= ref3 ? ++m : --m) {
       f *= i;
     }
     return f;
@@ -47,18 +49,18 @@
   };
 
   rotateLeft = function(array, l, r) {
-    var i, m, ref2, ref3, tmp;
+    var i, m, ref3, ref4, tmp;
     tmp = array[l];
-    for (i = m = ref2 = l, ref3 = r - 1; ref2 <= ref3 ? m <= ref3 : m >= ref3; i = ref2 <= ref3 ? ++m : --m) {
+    for (i = m = ref3 = l, ref4 = r - 1; ref3 <= ref4 ? m <= ref4 : m >= ref4; i = ref3 <= ref4 ? ++m : --m) {
       array[i] = array[i + 1];
     }
     return array[r] = tmp;
   };
 
   rotateRight = function(array, l, r) {
-    var i, m, ref2, ref3, tmp;
+    var i, m, ref3, ref4, tmp;
     tmp = array[r];
-    for (i = m = ref2 = r, ref3 = l + 1; ref2 <= ref3 ? m <= ref3 : m >= ref3; i = ref2 <= ref3 ? ++m : --m) {
+    for (i = m = ref3 = r, ref4 = l + 1; ref3 <= ref4 ? m <= ref4 : m >= ref4; i = ref3 <= ref4 ? ++m : --m) {
       array[i] = array[i - 1];
     }
     return array[l] = tmp;
@@ -79,26 +81,26 @@
       permName = 'ep';
     }
     our = (function() {
-      var m, ref2, results;
+      var m, ref3, results;
       results = [];
-      for (i = m = 0, ref2 = maxOur; 0 <= ref2 ? m <= ref2 : m >= ref2; i = 0 <= ref2 ? ++m : --m) {
+      for (i = m = 0, ref3 = maxOur; 0 <= ref3 ? m <= ref3 : m >= ref3; i = 0 <= ref3 ? ++m : --m) {
         results.push(0);
       }
       return results;
     })();
     return function(index) {
-      var a, b, c, j, k, m, o, p, perm, q, ref10, ref11, ref12, ref2, ref3, ref4, ref5, ref6, ref7, ref8, ref9, t, u, w, x, y, z;
+      var a, b, c, j, k, m, o, p, perm, q, ref10, ref11, ref12, ref13, ref3, ref4, ref5, ref6, ref7, ref8, ref9, t, u, w, x, y, z;
       if (index != null) {
-        for (i = m = 0, ref2 = maxOur; 0 <= ref2 ? m <= ref2 : m >= ref2; i = 0 <= ref2 ? ++m : --m) {
+        for (i = m = 0, ref3 = maxOur; 0 <= ref3 ? m <= ref3 : m >= ref3; i = 0 <= ref3 ? ++m : --m) {
           our[i] = i + start;
         }
         b = index % maxB;
         a = index / maxB | 0;
         perm = this[permName];
-        for (i = o = 0, ref3 = maxAll; 0 <= ref3 ? o <= ref3 : o >= ref3; i = 0 <= ref3 ? ++o : --o) {
+        for (i = o = 0, ref4 = maxAll; 0 <= ref4 ? o <= ref4 : o >= ref4; i = 0 <= ref4 ? ++o : --o) {
           perm[i] = -1;
         }
-        for (j = p = 1, ref4 = maxOur; 1 <= ref4 ? p <= ref4 : p >= ref4; j = 1 <= ref4 ? ++p : --p) {
+        for (j = p = 1, ref5 = maxOur; 1 <= ref5 ? p <= ref5 : p >= ref5; j = 1 <= ref5 ? ++p : --p) {
           k = b % (j + 1);
           b = b / (j + 1) | 0;
           while (k > 0) {
@@ -108,7 +110,7 @@
         }
         x = maxOur;
         if (fromEnd) {
-          for (j = q = 0, ref5 = maxAll; 0 <= ref5 ? q <= ref5 : q >= ref5; j = 0 <= ref5 ? ++q : --q) {
+          for (j = q = 0, ref6 = maxAll; 0 <= ref6 ? q <= ref6 : q >= ref6; j = 0 <= ref6 ? ++q : --q) {
             c = Cnk(maxAll - j, x + 1);
             if (a - c >= 0) {
               perm[j] = our[maxOur - x];
@@ -117,7 +119,7 @@
             }
           }
         } else {
-          for (j = t = ref6 = maxAll; ref6 <= 0 ? t <= 0 : t >= 0; j = ref6 <= 0 ? ++t : --t) {
+          for (j = t = ref7 = maxAll; ref7 <= 0 ? t <= 0 : t >= 0; j = ref7 <= 0 ? ++t : --t) {
             c = Cnk(j, x + 1);
             if (a - c >= 0) {
               perm[j] = our[x];
@@ -129,28 +131,28 @@
         return this;
       } else {
         perm = this[permName];
-        for (i = u = 0, ref7 = maxOur; 0 <= ref7 ? u <= ref7 : u >= ref7; i = 0 <= ref7 ? ++u : --u) {
+        for (i = u = 0, ref8 = maxOur; 0 <= ref8 ? u <= ref8 : u >= ref8; i = 0 <= ref8 ? ++u : --u) {
           our[i] = -1;
         }
         a = b = x = 0;
         if (fromEnd) {
-          for (j = w = ref8 = maxAll; ref8 <= 0 ? w <= 0 : w >= 0; j = ref8 <= 0 ? ++w : --w) {
-            if ((start <= (ref9 = perm[j]) && ref9 <= end)) {
+          for (j = w = ref9 = maxAll; ref9 <= 0 ? w <= 0 : w >= 0; j = ref9 <= 0 ? ++w : --w) {
+            if ((start <= (ref10 = perm[j]) && ref10 <= end)) {
               a += Cnk(maxAll - j, x + 1);
               our[maxOur - x] = perm[j];
               x++;
             }
           }
         } else {
-          for (j = y = 0, ref10 = maxAll; 0 <= ref10 ? y <= ref10 : y >= ref10; j = 0 <= ref10 ? ++y : --y) {
-            if ((start <= (ref11 = perm[j]) && ref11 <= end)) {
+          for (j = y = 0, ref11 = maxAll; 0 <= ref11 ? y <= ref11 : y >= ref11; j = 0 <= ref11 ? ++y : --y) {
+            if ((start <= (ref12 = perm[j]) && ref12 <= end)) {
               a += Cnk(j, x + 1);
               our[x] = perm[j];
               x++;
             }
           }
         }
-        for (j = z = ref12 = maxOur; ref12 <= 0 ? z <= 0 : z >= 0; j = ref12 <= 0 ? ++z : --z) {
+        for (j = z = ref13 = maxOur; ref13 <= 0 ? z <= 0 : z >= 0; j = ref13 <= 0 ? ++z : --z) {
           k = 0;
           while (our[j] !== start + j) {
             rotateLeft(our, 0, j);
@@ -205,10 +207,10 @@
       }
     },
     cornerParity: function() {
-      var i, j, m, o, ref2, ref3, ref4, ref5, s;
+      var i, j, m, o, ref3, ref4, ref5, ref6, s;
       s = 0;
-      for (i = m = ref2 = DRB, ref3 = URF + 1; ref2 <= ref3 ? m <= ref3 : m >= ref3; i = ref2 <= ref3 ? ++m : --m) {
-        for (j = o = ref4 = i - 1, ref5 = URF; ref4 <= ref5 ? o <= ref5 : o >= ref5; j = ref4 <= ref5 ? ++o : --o) {
+      for (i = m = ref3 = DRB, ref4 = URF + 1; ref3 <= ref4 ? m <= ref4 : m >= ref4; i = ref3 <= ref4 ? ++m : --m) {
+        for (j = o = ref5 = i - 1, ref6 = URF; ref5 <= ref6 ? o <= ref6 : o >= ref6; j = ref5 <= ref6 ? ++o : --o) {
           if (this.cp[j] > this.cp[i]) {
             s++;
           }
@@ -217,10 +219,10 @@
       return s % 2;
     },
     edgeParity: function() {
-      var i, j, m, o, ref2, ref3, ref4, ref5, s;
+      var i, j, m, o, ref3, ref4, ref5, ref6, s;
       s = 0;
-      for (i = m = ref2 = BR, ref3 = UR + 1; ref2 <= ref3 ? m <= ref3 : m >= ref3; i = ref2 <= ref3 ? ++m : --m) {
-        for (j = o = ref4 = i - 1, ref5 = UR; ref4 <= ref5 ? o <= ref5 : o >= ref5; j = ref4 <= ref5 ? ++o : --o) {
+      for (i = m = ref3 = BR, ref4 = UR + 1; ref3 <= ref4 ? m <= ref4 : m >= ref4; i = ref3 <= ref4 ? ++m : --m) {
+        for (j = o = ref5 = i - 1, ref6 = UR; ref5 <= ref6 ? o <= ref6 : o >= ref6; j = ref5 <= ref6 ? ++o : --o) {
           if (this.ep[j] > this.ep[i]) {
             s++;
           }
@@ -241,11 +243,11 @@
   }
 
   computeMoveTable = function(context, coord, size) {
-    var apply, cube, i, inner, j, k, m, move, o, p, ref2, results;
+    var apply, cube, i, inner, j, k, m, move, o, p, ref3, results;
     apply = context === 'corners' ? 'cornerMultiply' : 'edgeMultiply';
     cube = new Cube;
     results = [];
-    for (i = m = 0, ref2 = size - 1; 0 <= ref2 ? m <= ref2 : m >= ref2; i = 0 <= ref2 ? ++m : --m) {
+    for (i = m = 0, ref3 = size - 1; 0 <= ref3 ? m <= ref3 : m >= ref3; i = 0 <= ref3 ? ++m : --m) {
       cube[coord](i);
       inner = [];
       for (j = o = 0; o <= 5; j = ++o) {
@@ -326,7 +328,7 @@
   };
 
   Cube.computeMoveTables = function() {
-    var len, m, name, ref2, scope, size, tableName, tables;
+    var len, m, name, ref3, scope, size, tableName, tables;
     tables = 1 <= arguments.length ? slice1.call(arguments, 0) : [];
     if (tables.length === 0) {
       tables = (function() {
@@ -360,7 +362,7 @@
           return results;
         })();
       } else {
-        ref2 = moveTableParams[tableName], scope = ref2[0], size = ref2[1];
+        ref3 = moveTableParams[tableName], scope = ref3[0], size = ref3[1];
         this.moveTables[tableName] = computeMoveTable(scope, tableName, size);
       }
     }
@@ -423,11 +425,11 @@
   };
 
   computePruningTable = function(phase, size, currentCoords, nextIndex) {
-    var current, depth, done, index, len, m, move, moves, next, o, ref2, table, x;
+    var current, depth, done, index, len, m, move, moves, next, o, ref3, table, x;
     table = (function() {
-      var m, ref2, results;
+      var m, ref3, results;
       results = [];
-      for (x = m = 0, ref2 = Math.ceil(size / 8) - 1; 0 <= ref2 ? m <= ref2 : m >= ref2; x = 0 <= ref2 ? ++m : --m) {
+      for (x = m = 0, ref3 = Math.ceil(size / 8) - 1; 0 <= ref3 ? m <= ref3 : m >= ref3; x = 0 <= ref3 ? ++m : --m) {
         results.push(0xFFFFFFFF);
       }
       return results;
@@ -441,7 +443,7 @@
     pruning(table, 0, depth);
     done = 1;
     while (done !== size) {
-      for (index = m = 0, ref2 = size - 1; 0 <= ref2 ? m <= ref2 : m >= ref2; index = 0 <= ref2 ? ++m : --m) {
+      for (index = m = 0, ref3 = size - 1; 0 <= ref3 ? m <= ref3 : m >= ref3; index = 0 <= ref3 ? ++m : --m) {
         if (!(pruning(table, index) === depth)) {
           continue;
         }
@@ -545,7 +547,7 @@
     return Cube.computePruningTables();
   };
 
-  Cube.prototype.solve = function(maxDepth) {
+  Cube.prototype.solveUpright = function(maxDepth) {
     var State, freeStates, moveNames, phase1, phase1search, phase2, phase2search, solution, state, x;
     if (maxDepth == null) {
       maxDepth = 22;
@@ -680,10 +682,10 @@
     })();
     solution = null;
     phase1search = function(state) {
-      var depth, m, ref2, results;
+      var depth, m, ref3, results;
       depth = 0;
       results = [];
-      for (depth = m = 1, ref2 = maxDepth; 1 <= ref2 ? m <= ref2 : m >= ref2; depth = 1 <= ref2 ? ++m : --m) {
+      for (depth = m = 1, ref3 = maxDepth; 1 <= ref3 ? m <= ref3 : m >= ref3; depth = 1 <= ref3 ? ++m : --m) {
         phase1(state, depth);
         if (solution !== null) {
           break;
@@ -693,19 +695,19 @@
       return results;
     };
     phase1 = function(state, depth) {
-      var len, m, move, next, ref2, ref3, results;
+      var len, m, move, next, ref3, ref4, results;
       if (depth === 0) {
         if (state.minDist1() === 0) {
-          if (state.lastMove === null || (ref2 = state.lastMove, indexOf.call(allMoves2, ref2) < 0)) {
+          if (state.lastMove === null || (ref3 = state.lastMove, indexOf.call(allMoves2, ref3) < 0)) {
             return phase2search(state);
           }
         }
       } else if (depth > 0) {
         if (state.minDist1() <= depth) {
-          ref3 = state.moves1();
+          ref4 = state.moves1();
           results = [];
-          for (m = 0, len = ref3.length; m < len; m++) {
-            move = ref3[m];
+          for (m = 0, len = ref4.length; m < len; m++) {
+            move = ref4[m];
             next = state.next1(move);
             phase1(next, depth - 1);
             freeStates.push(next);
@@ -720,10 +722,10 @@
       }
     };
     phase2search = function(state) {
-      var depth, m, ref2, results;
+      var depth, m, ref3, results;
       state.init2();
       results = [];
-      for (depth = m = 1, ref2 = maxDepth - state.depth; 1 <= ref2 ? m <= ref2 : m >= ref2; depth = 1 <= ref2 ? ++m : --m) {
+      for (depth = m = 1, ref3 = maxDepth - state.depth; 1 <= ref3 ? m <= ref3 : m >= ref3; depth = 1 <= ref3 ? ++m : --m) {
         phase2(state, depth);
         if (solution !== null) {
           break;
@@ -733,17 +735,17 @@
       return results;
     };
     phase2 = function(state, depth) {
-      var len, m, move, next, ref2, results;
+      var len, m, move, next, ref3, results;
       if (depth === 0) {
         if (state.minDist2() === 0) {
           return solution = state.solution();
         }
       } else if (depth > 0) {
         if (state.minDist2() <= depth) {
-          ref2 = state.moves2();
+          ref3 = state.moves2();
           results = [];
-          for (m = 0, len = ref2.length; m < len; m++) {
-            move = ref2[m];
+          for (m = 0, len = ref3.length; m < len; m++) {
+            move = ref3[m];
             next = state.next2(move);
             phase2(next, depth - 1);
             freeStates.push(next);
@@ -758,9 +760,9 @@
       }
     };
     freeStates = (function() {
-      var m, ref2, results;
+      var m, ref3, results;
       results = [];
-      for (x = m = 0, ref2 = maxDepth + 1; 0 <= ref2 ? m <= ref2 : m >= ref2; x = 0 <= ref2 ? ++m : --m) {
+      for (x = m = 0, ref3 = maxDepth + 1; 0 <= ref3 ? m <= ref3 : m >= ref3; x = 0 <= ref3 ? ++m : --m) {
         results.push(new State);
       }
       return results;
@@ -772,6 +774,46 @@
       solution = solution.substring(0, solution.length - 1);
     }
     return solution;
+  };
+
+  faceNums = {
+    U: 0,
+    R: 1,
+    F: 2,
+    D: 3,
+    L: 4,
+    B: 5
+  };
+
+  faceNames = {
+    0: 'U',
+    1: 'R',
+    2: 'F',
+    3: 'D',
+    4: 'L',
+    5: 'B'
+  };
+
+  Cube.prototype.solve = function(maxDepth) {
+    var clone, len, m, move, ref3, rotation, solution, upright, uprightSolution;
+    if (maxDepth == null) {
+      maxDepth = 22;
+    }
+    clone = this.clone();
+    upright = clone.upright();
+    clone.move(upright);
+    rotation = new Cube().move(upright).center;
+    uprightSolution = clone.solveUpright(maxDepth);
+    solution = [];
+    ref3 = uprightSolution.split(' ');
+    for (m = 0, len = ref3.length; m < len; m++) {
+      move = ref3[m];
+      solution.push(faceNames[rotation[faceNums[move[0]]]]);
+      if (move.length > 1) {
+        solution[solution.length - 1] += move[1];
+      }
+    }
+    return solution.join(' ');
   };
 
   Cube.scramble = function() {

--- a/spec/cube.spec.coffee
+++ b/spec/cube.spec.coffee
@@ -5,13 +5,14 @@ describe 'Cube', ->
     expect(cube.asString()).toBe 'UUUUUUUUURRRRRRRRRFFFFFFFFFDDDDDDDDDLLLLLLLLLBBBBBBBBB'
 
   it 'should initiate a cube when provide a String', ->
-    cube = Cube.fromString 'UUUUUUUUUR...F...D...L...B...'
+    cube = Cube.fromString 'UUUUUUUUURRRRRRRRRFFFFFFFFFDDDDDDDDDLLLLLLLLLBBBBBBBBB'
     expect(cube.asString()).toBe 'UUUUUUUUURRRRRRRRRFFFFFFFFFDDDDDDDDDLLLLLLLLLBBBBBBBBB'
 
   it 'should serialize a cube to JSON for a default cube', ->
     cube = new Cube
 
     expectedJSON =
+      center: [0, 1, 2, 3, 4, 5],
       cp: [ 0, 1, 2, 3, 4, 5, 6, 7 ],
       co: [ 0, 0, 0, 0, 0, 0, 0, 0 ],
       ep: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ],
@@ -28,6 +29,11 @@ describe 'Cube', ->
     cube = new Cube
     cube.move "U R F' L'"
     expect(cube.asString()).toBe 'DURRUFRRRBRBDRBDRBFDDDFFDFFBLLBDBLDLFUUFLLFLLULRUBUUBU'
+
+  it 'should rotate cuve face when apply a moves sequence includes additional notation', ->
+    cube = new Cube
+    cube.move "M' u2 z' S"
+    expect(cube.asString()).toBe 'LLRUFULLRDLDBLBDRDBBFUUDBBFRRLDBDRRLURUFRFULUBFFUDDBFF'
 
   it 'should resets the cube to the identity cube', ->
     cube = new Cube

--- a/src/solve.coffee
+++ b/src/solve.coffee
@@ -1,5 +1,8 @@
 Cube = @Cube or require('./cube')
 
+# Centers
+[U, R, F, D, L, B] = [0..5]
+
 # Corners
 [URF, UFL, ULB, UBR, DFR, DLF, DBL, DRB] = [0..7]
 
@@ -474,7 +477,7 @@ Cube.initSolver = ->
   Cube.computeMoveTables()
   Cube.computePruningTables()
 
-Cube::solve = (maxDepth=22) ->
+Cube::solveUpright = (maxDepth=22) ->
   # Names for all moves, i.e. U, U2, U', F, F2, ...
   moveNames = do ->
     faceName = ['U', 'R', 'F', 'D', 'L', 'B']
@@ -668,6 +671,34 @@ Cube::solve = (maxDepth=22) ->
 
   solution
 
+faceNums =
+  U: 0
+  R: 1
+  F: 2
+  D: 3
+  L: 4
+  B: 5
+
+faceNames =
+  0: 'U'
+  1: 'R'
+  2: 'F'
+  3: 'D'
+  4: 'L'
+  5: 'B'
+
+Cube::solve = (maxDepth=22) ->
+  clone = @clone()
+  upright = clone.upright()
+  clone.move upright
+  rotation = new Cube().move(upright).center
+  uprightSolution = clone.solveUpright maxDepth
+  solution = []
+  for move in uprightSolution.split ' '
+    solution.push faceNames[rotation[faceNums[move[0]]]]
+    if move.length > 1
+      solution[solution.length - 1] += move[1]
+  solution.join ' '
 
 Cube.scramble = ->
   Cube.inverse(Cube.random().solve())


### PR DESCRIPTION
More moves are supported. Roughly, changes are:
* New property `cube.center` is added to cube state.
* New method `cube.upright()` is added. This returns an algorithm to rotate the cube to upright position. So, the returned algorithm by this method includes only x, y and z.
* `cube.solve()` is renamed to `solveUpright()` and new method `solve()` wraps it for solving rotated cube.

note:
* Sorry to say, I could not understand how [this test](https://github.com/ldez/cubejs/blob/c941205ac9da9682236e419332f424a55310cdfd/spec/cube.spec.coffee#L8) works, so I changed the test itself.
* This implementation is independent of the code of the pull request #10.