### PR TITLE
Fix Randomizer

### DIFF
--- a/lib/cube.js
+++ b/lib/cube.js
@@ -446,9 +446,8 @@
       };
       // Fisher-Yates shuffle adapted from https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
       shuffle = function(array) {
-        var currentIndex, randomIndex, results, temporaryValue;
+        var currentIndex, randomIndex, temporaryValue;
         currentIndex = array.length;
-        results = [];
         // While there remain elements to shuffle...
         while (currentIndex !== 0) {
           // Pick a remaining element...
@@ -456,9 +455,8 @@
           currentIndex -= 1;
           // And swap it with the current element.
           temporaryValue = array[currentIndex];
-          results.push([array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]]);
+          [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]];
         }
-        return results;
       };
       getNumSwaps = function(arr) {
         var cur, cycleLength, i, k, numSwaps, ref, seen, x;
@@ -500,26 +498,21 @@
         return numSwaps % 2 === 0;
       };
       generateValidRandomPermutation = function(cp, ep) {
-        var results;
         // Each shuffle only takes around 12 operations and there's a 50%
         // chance of a valid permutation so it'll finish in very good time
         shuffle(ep);
         shuffle(cp);
-        results = [];
         while (!arePermutationsValid(cp, ep)) {
           shuffle(ep);
-          results.push(shuffle(cp));
+          shuffle(cp);
         }
-        return results;
       };
       randomizeOrientation = function(arr, numOrientations) {
-        var i, k, ori, ref, results;
+        var i, k, ori, ref;
         ori = 0;
-        results = [];
         for (i = k = 0, ref = arr.length - 1; (0 <= ref ? k <= ref : k >= ref); i = 0 <= ref ? ++k : --k) {
-          results.push(ori += (arr[i] = randint(0, numOrientations - 1)));
+          ori += (arr[i] = randint(0, numOrientations - 1));
         }
-        return results;
       };
       isOrientationValid = function(arr, numOrientations) {
         return arr.reduce(function(a, b) {
@@ -527,7 +520,6 @@
         }) % numOrientations === 0;
       };
       generateValidRandomOrientation = function(co, eo) {
-        var results;
         // There is a 1/2 and 1/3 probably respectively of each of these
         // succeeding so the probability of them running 10 times before
         // success is already only 1% and only gets exponentially lower
@@ -537,11 +529,9 @@
           randomizeOrientation(co, 3);
         }
         randomizeOrientation(eo, 2);
-        results = [];
         while (!isOrientationValid(eo, 2)) {
-          results.push(randomizeOrientation(eo, 2));
+          randomizeOrientation(eo, 2);
         }
-        return results;
       };
       result = function() {
         generateValidRandomPermutation(this.cp, this.ep);

--- a/lib/cube.js
+++ b/lib/cube.js
@@ -217,7 +217,7 @@
       }
 
       static fromString(str) {
-        var col1, col2, cube, i, j, k, l, m, o, ori, p, q, ref, s;
+        var col1, col2, cube, i, j, k, l, m, o, ori, p, q, r, ref;
         cube = new Cube;
         for (i = k = 0; k <= 5; i = ++k) {
           for (j = l = 0; l <= 5; j = ++l) {
@@ -242,7 +242,7 @@
           }
         }
         for (i = q = 0; q <= 11; i = ++q) {
-          for (j = s = 0; s <= 11; j = ++s) {
+          for (j = r = 0; r <= 11; j = ++r) {
             if (str[edgeFacelet[i][0]] === edgeColor[j][0] && str[edgeFacelet[i][1]] === edgeColor[j][1]) {
               cube.ep[i] = j;
               cube.eo[i] = 0;
@@ -440,41 +440,112 @@
     };
 
     Cube.prototype.randomize = (function() {
-      var mixPerm, randOri, randint, result;
+      var arePermutationsValid, generateValidRandomOrientation, generateValidRandomPermutation, getNumSwaps, isOrientationValid, randint, randomizeOrientation, result, shuffle;
       randint = function(min, max) {
-        return min + (Math.random() * (max - min + 1) | 0);
+        return min + Math.floor(Math.random() * (max - min + 1));
       };
-      mixPerm = function(arr) {
-        var i, k, max, r, ref, results;
-        max = arr.length - 1;
+      // Fisher-Yates shuffle adapted from https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
+      shuffle = function(array) {
+        var currentIndex, randomIndex, results, temporaryValue;
+        currentIndex = array.length;
         results = [];
-        for (i = k = 0, ref = max - 2; (0 <= ref ? k <= ref : k >= ref); i = 0 <= ref ? ++k : --k) {
-          r = randint(i, max);
-          // Ensure an even number of swaps
-          if (i !== r) {
-            [arr[i], arr[r]] = [arr[r], arr[i]];
-            results.push([arr[max], arr[max - 1]] = [arr[max - 1], arr[max]]);
-          } else {
-            results.push(void 0);
-          }
+        // While there remain elements to shuffle...
+        while (currentIndex !== 0) {
+          // Pick a remaining element...
+          randomIndex = randint(0, currentIndex - 1);
+          currentIndex -= 1;
+          // And swap it with the current element.
+          temporaryValue = array[currentIndex];
+          results.push([array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]]);
         }
         return results;
       };
-      randOri = function(arr, max) {
-        var i, k, ori, ref;
-        ori = 0;
-        for (i = k = 0, ref = arr.length - 2; (0 <= ref ? k <= ref : k >= ref); i = 0 <= ref ? ++k : --k) {
-          ori += (arr[i] = randint(0, max - 1));
+      getNumSwaps = function(arr) {
+        var cur, cycleLength, i, k, numSwaps, ref, seen, x;
+        numSwaps = 0;
+        seen = (function() {
+          var k, ref, results;
+          results = [];
+          for (x = k = 0, ref = arr.length - 1; (0 <= ref ? k <= ref : k >= ref); x = 0 <= ref ? ++k : --k) {
+            results.push(false);
+          }
+          return results;
+        })();
+        while (true) {
+          // We compute the cycle decomposition
+          cur = -1;
+          for (i = k = 0, ref = arr.length - 1; (0 <= ref ? k <= ref : k >= ref); i = 0 <= ref ? ++k : --k) {
+            if (!seen[i]) {
+              cur = i;
+              break;
+            }
+          }
+          if (cur === -1) {
+            break;
+          }
+          cycleLength = 0;
+          while (!seen[cur]) {
+            seen[cur] = true;
+            cycleLength++;
+            cur = arr[cur];
+          }
+          // A cycle is equivalent to cycleLength + 1 swaps
+          numSwaps += cycleLength + 1;
         }
-        // Set the orientation of the last cubie so that the cube is
-        // valid
-        return arr[arr.length - 1] = (max - ori % max) % max;
+        return numSwaps;
+      };
+      arePermutationsValid = function(cp, ep) {
+        var numSwaps;
+        numSwaps = getNumSwaps(ep) + getNumSwaps(cp);
+        return numSwaps % 2 === 0;
+      };
+      generateValidRandomPermutation = function(cp, ep) {
+        var results;
+        // Each shuffle only takes around 12 operations and there's a 50%
+        // chance of a valid permutation so it'll finish in very good time
+        shuffle(ep);
+        shuffle(cp);
+        results = [];
+        while (!arePermutationsValid(cp, ep)) {
+          shuffle(ep);
+          results.push(shuffle(cp));
+        }
+        return results;
+      };
+      randomizeOrientation = function(arr, numOrientations) {
+        var i, k, ori, ref, results;
+        ori = 0;
+        results = [];
+        for (i = k = 0, ref = arr.length - 1; (0 <= ref ? k <= ref : k >= ref); i = 0 <= ref ? ++k : --k) {
+          results.push(ori += (arr[i] = randint(0, numOrientations - 1)));
+        }
+        return results;
+      };
+      isOrientationValid = function(arr, numOrientations) {
+        return arr.reduce(function(a, b) {
+          return a + b;
+        }) % numOrientations === 0;
+      };
+      generateValidRandomOrientation = function(co, eo) {
+        var results;
+        // There is a 1/2 and 1/3 probably respectively of each of these
+        // succeeding so the probability of them running 10 times before
+        // success is already only 1% and only gets exponentially lower
+        // and each generation is only in the 10s of operations which is nothing
+        randomizeOrientation(co, 3);
+        while (!isOrientationValid(co, 3)) {
+          randomizeOrientation(co, 3);
+        }
+        randomizeOrientation(eo, 2);
+        results = [];
+        while (!isOrientationValid(eo, 2)) {
+          results.push(randomizeOrientation(eo, 2));
+        }
+        return results;
       };
       result = function() {
-        mixPerm(this.cp);
-        mixPerm(this.ep);
-        randOri(this.co, 3);
-        randOri(this.eo, 2);
+        generateValidRandomPermutation(this.cp, this.ep);
+        generateValidRandomOrientation(this.co, this.eo);
         return this;
       };
       return result;

--- a/spec/cube.spec.coffee
+++ b/spec/cube.spec.coffee
@@ -45,7 +45,7 @@ describe 'Cube', ->
     cube = new Cube
     expect(cube.isSolved()).toBe true
 
-  it 'should return false when the cube is not solved (random cube)', ->
+  it 'should return false when the cube is not solved (random cube), and runs without errors in normal time', ->
     cube = Cube.random()
     expect(cube.isSolved()).toBe false
 

--- a/src/cube.coffee
+++ b/src/cube.coffee
@@ -139,7 +139,7 @@ class Cube
 
   randomize: do ->
     randint = (min, max) ->
-      return min + Math.floor(Math.random() * (max - min + 1) )
+      min + Math.floor(Math.random() * (max - min + 1) )
 
     # Fisher-Yates shuffle adapted from https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
     shuffle = (array) ->
@@ -155,7 +155,6 @@ class Cube
         temporaryValue = array[currentIndex]
         [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]]
       return
-
 
     getNumSwaps = (arr) ->
       numSwaps = 0
@@ -176,11 +175,11 @@ class Cube
           cur = arr[cur]
         # A cycle is equivalent to cycleLength + 1 swaps
         numSwaps += cycleLength + 1
-      return numSwaps
+      numSwaps
 
     arePermutationsValid = (cp, ep) ->
       numSwaps = getNumSwaps(ep) + getNumSwaps(cp)
-      return numSwaps % 2 is 0
+      numSwaps % 2 is 0
 
     generateValidRandomPermutation = (cp, ep) ->
       # Each shuffle only takes around 12 operations and there's a 50%
@@ -199,7 +198,7 @@ class Cube
       return
 
     isOrientationValid = (arr, numOrientations) ->
-      return arr.reduce((a, b) -> a + b) % numOrientations is 0
+      arr.reduce((a, b) -> a + b) % numOrientations is 0
 
     generateValidRandomOrientation = (co, eo) ->
       # There is a 1/2 and 1/3 probably respectively of each of these
@@ -213,16 +212,15 @@ class Cube
       randomizeOrientation(eo, 2)
       until isOrientationValid(eo, 2)
         randomizeOrientation(eo, 2)
+
       return
-
-
 
     result = ->
       generateValidRandomPermutation(@cp, @ep)
       generateValidRandomOrientation(@co, @eo)
-      return this
+      this
 
-    return result
+    result
 
   # A class method returning a new random cube
   @random: ->

--- a/src/cube.coffee
+++ b/src/cube.coffee
@@ -139,7 +139,7 @@ class Cube
 
   randomize: do ->
     randint = (min, max) ->
-      min + Math.floor(Math.random() * (max - min + 1) )
+      return min + Math.floor(Math.random() * (max - min + 1) )
 
     # Fisher-Yates shuffle adapted from https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
     shuffle = (array) ->
@@ -147,7 +147,6 @@ class Cube
 
       # While there remain elements to shuffle...
       while currentIndex isnt 0
-
         # Pick a remaining element...
         randomIndex = randint(0, currentIndex - 1)
         currentIndex -= 1
@@ -155,6 +154,7 @@ class Cube
         # And swap it with the current element.
         temporaryValue = array[currentIndex]
         [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]]
+      return
 
 
     getNumSwaps = (arr) ->
@@ -190,11 +190,13 @@ class Cube
       until arePermutationsValid(cp, ep)
         shuffle(ep)
         shuffle(cp)
+      return
 
     randomizeOrientation = (arr, numOrientations) ->
       ori = 0
       for i in [0..arr.length - 1]
         ori += (arr[i] = randint(0, numOrientations - 1))
+      return
 
     isOrientationValid = (arr, numOrientations) ->
       return arr.reduce((a, b) -> a + b) % numOrientations is 0
@@ -211,6 +213,7 @@ class Cube
       randomizeOrientation(eo, 2)
       until isOrientationValid(eo, 2)
         randomizeOrientation(eo, 2)
+      return
 
 
 
@@ -219,7 +222,7 @@ class Cube
       generateValidRandomOrientation(@co, @eo)
       return this
 
-    result
+    return result
 
   # A class method returning a new random cube
   @random: ->

--- a/src/cube.coffee
+++ b/src/cube.coffee
@@ -146,14 +146,14 @@ class Cube
       currentIndex = array.length
 
       # While there remain elements to shuffle...
-      while (currentIndex != 0)
+      while currentIndex isnt 0
 
         # Pick a remaining element...
-        randomIndex = randint(0, currentIndex - 1);
-        currentIndex -= 1;
+        randomIndex = randint(0, currentIndex - 1)
+        currentIndex -= 1
 
         # And swap it with the current element.
-        temporaryValue = array[currentIndex];
+        temporaryValue = array[currentIndex]
         [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]]
 
 
@@ -161,13 +161,13 @@ class Cube
       numSwaps = 0
       seen = (false for x in [0..arr.length - 1])
       # We compute the cycle decomposition
-      while(1)
+      loop
         cur = -1
         for i in [0..arr.length - 1]
           if not seen[i]
             cur = i
             break
-        if cur == -1
+        if cur is -1
           break
         cycleLength = 0
         while not seen[cur]
@@ -178,18 +178,18 @@ class Cube
         numSwaps += cycleLength + 1
       return numSwaps
 
-    arePermutationsValid = () ->
-      numSwaps = getNumSwaps(@ep) + getNumSwaps(@cp)
-      return numSwaps % 2 == 0
+    arePermutationsValid = (cp, ep) ->
+      numSwaps = getNumSwaps(ep) + getNumSwaps(cp)
+      return numSwaps % 2 is 0
 
-    generateValidRandomPermutation = () ->
+    generateValidRandomPermutation = (cp, ep) ->
       # Each shuffle only takes around 12 operations and there's a 50%
       # chance of a valid permutation so it'll finish in very good time
-      shuffle(@ep)
-      shuffle(@cp)
-      while not arePermutationsValid()
-        shuffle(@ep)
-        shuffle(@cp)
+      shuffle(ep)
+      shuffle(cp)
+      until arePermutationsValid(cp, ep)
+        shuffle(ep)
+        shuffle(cp)
 
     randomizeOrientation = (arr, numOrientations) ->
       ori = 0
@@ -197,24 +197,26 @@ class Cube
         ori += (arr[i] = randint(0, numOrientations - 1))
 
     isOrientationValid = (arr, numOrientations) ->
-      return arr.reduce((a, b) -> a + b) % numOrientations == 0
+      return arr.reduce((a, b) -> a + b) % numOrientations is 0
 
-    generateValidRandomOrientation = () ->
+    generateValidRandomOrientation = (co, eo) ->
       # There is a 1/2 and 1/3 probably respectively of each of these
       # succeeding so the probability of them running 10 times before
       # success is already only 1% and only gets exponentially lower
       # and each generation is only in the 10s of operations which is nothing
-      randomizeOrientation(@co, 3)
-      while (not isOrientationValid(@co, 3)) randomizeOrientation(@co, 3)
+      randomizeOrientation(co, 3)
+      until isOrientationValid(co, 3)
+        randomizeOrientation(co, 3)
 
-      randomizeOrientation(@eo, 2)
-      while (not isOrientationValid(@eo, 2)) randomizeOrientation(@eo, 2)
+      randomizeOrientation(eo, 2)
+      until isOrientationValid(eo, 2)
+        randomizeOrientation(eo, 2)
 
 
 
     result = ->
-      generateValidRandomPermutation()
-      generateValidRandomOrientation()
+      generateValidRandomPermutation(@cp, @ep)
+      generateValidRandomOrientation(@co, @eo)
       return this
 
     result
@@ -245,7 +247,7 @@ class Cube
     for to in [0..5]
       from = other.center[to]
       @newCenter[to] = @center[from]
-    
+
     [@center, @newCenter] = [@newCenter, @center]
     this
 


### PR DESCRIPTION
I fixed the randomizer which will resolve #14 

I focused on being sure it was random, so I simply do a completely random allocation and then validate it and retry until it's valid. It's easy to prove that the probability of no valid ones being found within even just 10-20 tries already is below 1% and it only goes exponentially lower after that, and since each operation is only in the 10s of operations it's negligible work for a normal modern computer that does 10^9 operations a second.

I've tested it on my app I'm using it on and I'm getting both odd and even parities and it runs in negligible time as expected