### PR TITLE
fix: return null instead of crashing when no solution is found

### DIFF
--- a/docs/lib/solve.js
+++ b/docs/lib/solve.js
@@ -905,6 +905,9 @@
     state = freeStates.pop().init(this);
     phase1search(state);
     freeStates.push(state);
+    if (solution == null) {
+      return null;
+    }
     // Trim the trailing space and return
     return solution.trim();
   };
@@ -934,6 +937,9 @@
     clone.move(upright);
     rotation = new Cube().move(upright).center;
     uprightSolution = clone.solveUpright(maxDepth);
+    if (uprightSolution == null) {
+      return null;
+    }
     solution = [];
     ref = uprightSolution.split(' ');
     for (m = 0, len = ref.length; m < len; m++) {

--- a/lib/solve.js
+++ b/lib/solve.js
@@ -905,6 +905,9 @@
     state = freeStates.pop().init(this);
     phase1search(state);
     freeStates.push(state);
+    if (solution == null) {
+      return null;
+    }
     // Trim the trailing space and return
     return solution.trim();
   };
@@ -934,6 +937,9 @@
     clone.move(upright);
     rotation = new Cube().move(upright).center;
     uprightSolution = clone.solveUpright(maxDepth);
+    if (uprightSolution == null) {
+      return null;
+    }
     solution = [];
     ref = uprightSolution.split(' ');
     for (m = 0, len = ref.length; m < len; m++) {

--- a/spec/cube.spec.coffee
+++ b/spec/cube.spec.coffee
@@ -58,3 +58,9 @@ describe 'Cube', ->
     Cube.initSolver()
     cube = new Cube
     expect(cube.solve()).toBe "R L U2 R L F2 R2 U2 R2 F2 R2 U2 F2 L2"
+
+  # ignore because Travis is slow
+  xit 'should return null if no solution is found (maxDepth too low)', ->
+    Cube.initSolver()
+    cube = Cube.random()
+    expect(cube.solve(1)).toBe null

--- a/src/solve.coffee
+++ b/src/solve.coffee
@@ -662,6 +662,7 @@ Cube::solveUpright = (maxDepth=22) ->
   phase1search(state)
   freeStates.push(state)
 
+  return null if not solution?
   # Trim the trailing space and return
   solution.trim()
 
@@ -687,6 +688,7 @@ Cube::solve = (maxDepth=22) ->
   clone.move upright
   rotation = new Cube().move(upright).center
   uprightSolution = clone.solveUpright maxDepth
+  return null if not uprightSolution?
   solution = []
   for move in uprightSolution.split ' '
     solution.push faceNames[rotation[faceNums[move[0]]]]


### PR DESCRIPTION
When no solution can be found cubejs crashes while trying to access `null`.

This happens when `maxDepth` is set too low for the current scramble.
To reproduce this bug just set it to 1 (see also the added test).

I usually don't use CoffeScript, so I hope the syntax is ok. Otherwise, feel free to edit it. :)